### PR TITLE
Removed year (2010) from BoilerplateCommentSniff.

### DIFF
--- a/codechecker/CodeSniffer/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/codechecker/CodeSniffer/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -43,7 +43,7 @@ class moodle_Sniffs_Files_BoilerplateCommentSniff implements PHP_CodeSniffer_Sni
         "/*",
         " * This file is part of Totara LMS",
         " *",
-        " * Copyright (C) 2010",
+        " * Copyright (C)",
         " *",
         " * This program is free software; you can redistribute it and/or modify",
         " * it under the terms of the GNU General Public License as published by",


### PR DESCRIPTION
This was causing a code smell for third party copyright blocks.
