### PR TITLE
Allow PHP docblock comments for opening copyright statements.

### DIFF
--- a/codechecker/CodeSniffer/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/codechecker/CodeSniffer/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -112,9 +112,11 @@ class moodle_Sniffs_Files_BoilerplateCommentSniff implements PHP_CodeSniffer_Sni
             }
 
             $regex = str_replace('Moodle', '.*', '/^' . preg_quote($line, '/') . '/');
-            if ($tokens[$tokenptr]['code'] != T_COMMENT ||
-                    !preg_match($regex, $tokens[$tokenptr]['content'])) {
 
+            $iscomment = $tokens[$tokenptr]['code'] == T_COMMENT ||
+                         $tokens[$tokenptr]['code'] == T_DOC_COMMENT;
+
+            if (!$iscomment || !preg_match($regex, $tokens[$tokenptr]['content']) ) {
                 $file->addError('Line %s of the opening comment must start "%s".',
                         $tokenptr, 'WrongLine', array($lineindex + 1, $line));
             }


### PR DESCRIPTION
NB the docblock style is the specified style in the Coding Style guide on the Totara developer wiki: https://dev.totaralms.com/wiki/Guide/Developing/Coding_style

This change will still allow either the docblock-style or the currently permitted C-style comments.
